### PR TITLE
import changes to date from fbc/src/rtlib (fbc 1.09.0)

### DIFF
--- a/fb_private_thread.bi
+++ b/fb_private_thread.bi
@@ -15,6 +15,22 @@
 	end type
 #endif
 
+/' Solaris pthread.h does not define PTHREAD_STACK_MIN '/
+#ifndef PTHREAD_STACK_MIN
+	#define PTHREAD_STACK_MIN 8192
+#endif
+
+/' phtreads will crash freebsd when stack size is too small
+// The default of 2 KiB is too small.as tested on freebsd-13.0-i386
+// 8 KiB seems about alright (jeffm) 
+// see https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=234775
+'/
+#ifdef HOST_FREEBSD
+	#define FBTHREAD_STACK_MIN 8192
+#else
+	#define FBTHREAD_STACK_MIN PTHREAD_STACK_MIN
+#endif
+
 /' Thread handle returned by threadcreate(), so the caller is able to track the
    thread (freed by threadwait/threaddetach).
 

--- a/strw_convfrom_str.bas
+++ b/strw_convfrom_str.bas
@@ -3,6 +3,29 @@
 #include "fb.bi"
 
 extern "C"
+private function fb_wstr_ConvFromA_nomultibyte( dst as FB_WCHAR ptr, dst_chars as ssize_t, src as const ubyte ptr ) as ssize_t
+
+	/' mbstowcs() must have failed; translate at least ASCII chars
+	   and write out '?' for the others '/
+	dim as FB_WCHAR ptr origdst = dst
+	dim as FB_WCHAR ptr dstlimit = dst + dst_chars
+	while (dst < dstlimit)
+		dim as ubyte c = *src 
+		src += 1
+		if (c = 0) then
+			exit while
+		end if
+		if (c > 127) then
+			c = 63
+		end if
+		*dst = c
+		*dst += 1
+	wend
+	*dst = asc(!"\000") '' NUL CHAR
+	return dst - origdst
+end function
+
+
 /' dst_chars == room in dst buffer without null terminator. Thus, the dst buffer
    must be at least (dst_chars + 1) * sizeof(FB_WCHAR).
    src must be null-terminated.
@@ -37,23 +60,11 @@ function fb_wstr_ConvFromA( dst as FB_WCHAR ptr, dst_chars as ssize_t, src as co
 		return chars
 	end if
 
-	/' mbstowcs() failed; translate at least ASCII chars
-	   and write out '?' for the others '/
-	dim as FB_WCHAR ptr origdst = dst
-	dim as FB_WCHAR ptr dstlimit = dst + dst_chars
-	while (dst < dstlimit)
-		dim as ubyte c = *src + 1
-		if (c = 0) then
-			exit while
-		end if
-		if (c > 127) then
-			c = 63
-		end if
-		*dst += 1
-		*dst = c
-	wend
-	*dst = asc(!"\000") '' NUL CHAR
-	return dst - origdst
+	/' mbstowcs() failed?; translate at least ASCII chars
+	'' and write out '?' for the others
+	'/
+	return fb_wstr_ConvFromA_nomultibyte( dst, dst_chars, src )
+
 #endif
 end function
 
@@ -61,22 +72,44 @@ function fb_StrToWstr FBCALL ( src as const ubyte ptr ) as FB_WCHAR ptr
 	dim as FB_WCHAR ptr dst
 	dim as ssize_t chars
 
-    if ( src = NULL ) then
-    	return NULL
+	if( src = NULL ) then
+		return NULL
 	end if
 
+#if defined( __FB_DOS__ )
+	/' on DOS, mbstowcs() simply calls memcpy() and won't compute
+	length  see fb_unicode.h '/
 	chars = strlen( src )
-    if ( chars = 0 ) then
-    	return NULL
+#else
+	chars = mbstowcs( NULL, src, 0 )
+
+	/' invalid multibyte characters? get the plain old NUL terminated 
+	'' string length and allocate a buffer for at least the ASCII chars 
+	'/
+	if( chars < 0 ) then
+		chars = strlen( src )
+		dst = fb_wstr_AllocTemp( chars )
+		if( dst = NULL ) then
+			return NULL
+		end if
+		/' don't bother calling fb_wstr_ConvFromA() it will just call the trivial conversion anyway '/
+		fb_wstr_ConvFromA_nomultibyte( dst, chars, src )
+		return dst
 	end if
 
-    dst = fb_wstr_AllocTemp( chars )
-	if ( dst = NULL ) then
+#endif
+	if( chars = 0 ) then
+		return NULL
+	end if
+
+	dst = fb_wstr_AllocTemp( chars )
+	if( dst = NULL ) then
 		return NULL
 	end if
 
 	fb_wstr_ConvFromA( dst, chars, src )
 
 	return dst
+
 end function
 end extern


### PR DESCRIPTION
This pull request synchronizes changes from the C source in to the fbrtLib translation:

- sf.net #942 string to wstr conversion fails for invalid multibyte characters, see https://sourceforge.net/p/fbc/bugs/942/
- rtlib: freebsd: minimum thread stacksize 8192 KiB, see https://github.com/freebasic/fbc/commit/7b91e93e968ced224ab3ae426d2fc2952a9eb20e

The changes are made with respect to fbc 1.09.0, however the library API is still compatible so should also be also usable with fbc 1.08.x