### PR TITLE
Import changes from fbc/src/rtlib (fbc-1.09)

### DIFF
--- a/array_clearobj.bas
+++ b/array_clearobj.bas
@@ -3,25 +3,15 @@
 #include "fb.bi"
 
 extern "C"
-sub fb_hArrayCtorObj( array as FBARRAY ptr, ctor as FB_DEFCTOR, base_idx as size_t )
-	dim as size_t i, elements, element_len
-	dim as FBARRAYDIM ptr _dim
+sub fb_hArrayCtorObj( array as FBARRAY ptr, ctor as FB_DEFCTOR )
+	dim as size_t elements, element_len
 	dim as ubyte ptr this_
 
 	if ( array->_ptr = NULL ) then
 		exit sub
 	end if
 	
-	_dim = @array->dimTB(0)
-	elements = _dim->elements - base_idx
-	_dim += 1
-
-	i = 1
-	while( i < array->dimensions )
-		elements *= _dim->elements
-		i += 1
-		_dim += 1
-	wend
+	elements = fb_ArrayLen( array )
 
 	/' call ctors '/
 	element_len = array->element_len
@@ -45,7 +35,7 @@ function fb_ArrayClearObj FBCALL ( array as FBARRAY ptr, ctor as FB_DEFCTOR, dto
 	/' re-initialize (ctor can be NULL if there only is a dtor) '/
 	if( ctor <> 0) then
 		/' if a ctor exists, it should handle the whole initialization '/
-		fb_hArrayCtorObj( array, ctor, 0 )
+		fb_hArrayCtorObj( array, ctor )
 	else
 		/' otherwise, just clear '/
 		fb_ArrayClear( array )

--- a/array_core.bas
+++ b/array_core.bas
@@ -3,6 +3,11 @@
 #include "fb.bi"
 
 extern "C"
+
+/' calculate the number of array elements based on the passed
+   in to fb_hArrayRealloc().  Note that this is a different
+   format than the arrary->dimTB[] table
+'/
 function fb_hArrayCalcElements ( dimensions as size_t, lboundTB as const ssize_t ptr, uboundTB as const ssize_t ptr ) as size_t
 	dim as size_t i, elements
 
@@ -35,4 +40,50 @@ function fb_hArrayCalcDiff ( dimensions as size_t, lboundTB as const ssize_t ptr
 
 	return -diff
 end function
+
+function fb_ArrayLen FBCALL ( array as FBARRAY ptr ) as size_t
+
+	if( array ) then
+		if( array->_ptr ) then
+			return array->size / array->element_len
+		end if
+	end if
+	
+	return 0
+
+/'
+
+	Previously, the number of elements was computed from
+	the array descriptor's dimensions table.
+
+	scope
+		dim as FBARRAYDIM ptr _dim
+	
+		_dim = @array->dimTB(0)
+		elements = _dim->elements
+		_dim += 1
+	
+		i = 1
+		while( i < array->dimensions )
+			elements *= _dim->elements
+			i += 1
+			_dim += 1
+		wend
+		
+		return elements
+	end scope
+
+'/
+end function
+
+function fb_ArraySize FBCALL ( array as FBARRAY ptr ) as size_t 
+	if( array ) then
+		if( array->_ptr ) then
+			return array->size
+		end if
+	end if
+	
+	return 0
+end function
+
 end extern

--- a/array_destructobj.bas
+++ b/array_destructobj.bas
@@ -3,31 +3,21 @@
 #include "fb.bi"
 
 extern "C"
-sub fb_hArrayDtorObj ( array as FBARRAY ptr, dtor as FB_DEFCTOR, base_idx as size_t )
-	dim as size_t i, elements, element_len
-	dim as FBARRAYDIM ptr _dim
+sub fb_hArrayDtorObj ( array as FBARRAY ptr, dtor as FB_DEFCTOR, keep_idx as size_t )
+	dim as size_t elements, element_len
 	dim as ubyte ptr this_
 
 	if ( array->_ptr = NULL ) then
 		exit sub
 	end if
 
-	_dim = @array->dimTB(0)
-	elements = _dim->elements - base_idx
-	_dim += 1
-
-	i = 1
-	while( i < array->dimensions )
-		elements *= _dim->elements
-		i += 1
-		_dim += 1
-	wend
+	elements = fb_ArrayLen( array )
 
 	/' call dtors in the inverse order '/
 	element_len = array->element_len
-	this_ = cast(ubyte ptr, (array->_ptr)) + ((base_idx + (elements - 1)) * element_len)
+	this_ = cast(ubyte ptr, (array->_ptr)) + ((elements - 1) * element_len)
 
-	while( elements > 0 )
+	while( elements > keep_idx )
 		/' !!!FIXME!!! check exceptions (only if rewritten in C++) '/
 		dtor( this_ )
 		this_ -= element_len

--- a/array_destructstr.bas
+++ b/array_destructstr.bas
@@ -3,31 +3,20 @@
 #include "fb.bi"
 
 extern "C"
-sub fb_hArrayDtorStr ( array as FBARRAY ptr, dtor as FB_DEFCTOR, base_idx as size_t )
-	dim as size_t i
-	dim as ssize_t elements
-	dim as FBARRAYDIM ptr _dim
+sub fb_hArrayDtorStr ( array as FBARRAY ptr, dtor as FB_DEFCTOR, keep_idx as size_t )
+	dim as size_t elements
 	dim as FBSTRING ptr this_
 
 	if ( array->_ptr = NULL ) then
 		exit sub
 	end if
 
-	_dim = @array->dimTB(0)
-	elements = _dim->elements - base_idx
-	_dim += 1
-
-	i = 1
-	while( i < array->dimensions )
-		elements *= _dim->elements
-		i += 1
-		_dim += 1
-	wend
+	elements = fb_ArrayLen( array )
 
 	/' call dtors in the inverse order '/
-	this_ = cast(FBSTRING ptr, array->_ptr) + (base_idx + (elements-1))
+	this_ = cast(FBSTRING ptr, array->_ptr) + (elements-1)
 
-	while( elements > 0 )
+	while( elements > keep_idx )
 		if ( this_->data <> NULL ) then
 			fb_StrDelete( this_ )
 		end if

--- a/array_redimpresv.bas
+++ b/array_redimpresv.bas
@@ -33,19 +33,18 @@ function fb_hArrayRealloc ( array as FBARRAY ptr, element_len as size_t, doclear
 		i += 1
 	wend
 
-	/' shrinking the array? free unused elements '/
-	if ( dtor_mult <> NULL ) then
-		dim as size_t new_lb = (ubTB(0) - lbTB(0)) + 1
-		if ( new_lb < array->dimTB(0).elements ) then
-			/' !!!FIXME!!! check exceptions (only if rewritten in C++) '/
-			dtor_mult( array, dtor, new_lb )
-		end if
-	end if
-
 	/' calc size '/
 	elements = fb_hArrayCalcElements( dimensions, @lbTB(0), @ubTB(0) )
 	diff = fb_hArrayCalcDiff( dimensions, @lbTB(0), @ubTB(0) ) * element_len
 	size = elements * element_len
+
+	/' shrinking the array? free unused elements '/
+	if ( dtor_mult <> NULL ) then
+		if ( elements < fb_ArrayLen( array ) ) then
+			/' !!!FIXME!!! check exceptions (only if rewritten in C++) '/
+			dtor_mult( array, dtor, elements )
+		end if
+	end if
 
 	/' realloc '/
 	array->_ptr = realloc( array->_ptr, size )

--- a/crt_extra/stdlib.bi
+++ b/crt_extra/stdlib.bi
@@ -12,11 +12,11 @@ Extern "C"
 End Extern
 
 	'' Windows CRT doesn't have strto(u)ll
-	Private Function strtoull cdecl(ByVal valPtr As ZString Ptr, ByVal endPtr As byte Ptr Ptr, ByVal radix As Long) As ULongInt
+	Private Function strtoull cdecl(ByVal valPtr As const ZString Ptr, ByVal endPtr As byte Ptr Ptr, ByVal radix As Long) As ULongInt
 		Return _strtoui64(valPtr, endPtr, radix)
 	End Function
 
-	Private Function strtoll cdecl(ByVal valPtr As ZString Ptr, ByVal endPtr As byte Ptr Ptr, ByVal radix As Long) As LongInt
+	Private Function strtoll cdecl(ByVal valPtr As const ZString Ptr, ByVal endPtr As byte Ptr Ptr, ByVal radix As Long) As LongInt
 		Return _strtoi64(valPtr, endPtr, radix)
 	End Function
 

--- a/dev_file_encod_open.bas
+++ b/dev_file_encod_open.bas
@@ -165,7 +165,10 @@ function fb_DevFileOpenEncod ( handle as FB_FILE ptr, filename as const ubyte pt
 	end if
 
 fileCloseExit:
-	fclose( fp )
+	/' close the file if there was any error '/
+	if( errorRet <> FB_RTERROR_OK ) then
+		fclose( fp )
+	end if
 unlockExit:
 	FB_UNLOCK()
 deallocExit:

--- a/dev_file_open.bas
+++ b/dev_file_open.bas
@@ -150,8 +150,8 @@ function fb_DevFileOpen( handle as FB_FILE ptr, filename as const ubyte ptr, fna
 		/' calc file size '/
 		handle->size = fb_DevFileGetSize( fp, handle->mode, handle->encod, TRUE )
 		if ( handle->size = -1 ) then
-		errorRet = FB_RTERROR_ILLEGALFUNCTIONCALL 
-		goto fileCloseExit
+			errorRet = FB_RTERROR_ILLEGALFUNCTIONCALL 
+			goto fileCloseExit
 		end if
 	end if
 
@@ -166,7 +166,10 @@ function fb_DevFileOpen( handle as FB_FILE ptr, filename as const ubyte ptr, fna
 	end if
 
 fileCloseExit:
-	fclose( fp )
+	/' close the file if there was any error '/
+	if( errorRet <> FB_RTERROR_OK ) then
+		fclose( fp )
+	end if
 unlockExit:
 	FB_UNLOCK()
 	free( fname )

--- a/dev_scrn.bas
+++ b/dev_scrn.bas
@@ -47,7 +47,7 @@ end function
 sub fb_DevScrnInit( )
     FB_LOCK( )
     if ( FB_HANDLE_SCREEN->hooks = NULL ) then
-        Clear(FB_HANDLE_SCREEN, 0, sizeof(*FB_HANDLE_SCREEN))
+        memset(FB_HANDLE_SCREEN, 0, sizeof(*FB_HANDLE_SCREEN))
 
         FB_HANDLE_SCREEN->mode = FB_FILE_MODE_APPEND
         FB_HANDLE_SCREEN->encod = FB_FILE_ENCOD_DEFAULT

--- a/dev_scrn_init.bas
+++ b/dev_scrn_init.bas
@@ -17,7 +17,7 @@ end sub
 sub fb_DevScrnMaybeUpdateWidth( )
 	/' Only if it was initialized (i.e. used) yet, otherwise we don't need
 	   to bother '/
-	if ( FB_HANDLE_SCREEN->hooks <> 0 ) then
+	if ( FB_HANDLE_SCREEN->hooks ) then
 		fb_DevScrnUpdateWidth( )
 	end if
 end sub
@@ -29,14 +29,16 @@ sub fb_DevScrnInit_Screen( )
 end sub
 
 sub fb_DevScrnEnd( handle as FB_FILE ptr )
-	free( handle->opaque )
-	handle->opaque = NULL
+	if( handle->opaque ) then
+		free( handle->opaque )
+		handle->opaque = NULL
+	end if
 end sub
 
 sub fb_DevScrnInit_NoOpen( )
 	FB_LOCK()
 	if ( FB_HANDLE_SCREEN->hooks = NULL ) then
-		Clear(FB_HANDLE_SCREEN, 0, sizeof(*FB_HANDLE_SCREEN))
+		memset(FB_HANDLE_SCREEN, 0, sizeof(*FB_HANDLE_SCREEN))
 
 		FB_HANDLE_SCREEN->mode = FB_FILE_MODE_APPEND
 		FB_HANDLE_SCREEN->type = FB_FILE_TYPE_VFS

--- a/fb_array.bi
+++ b/fb_array.bi
@@ -49,9 +49,11 @@ declare function fb_ArrayBoundChk 		FBCALL ( idx as ssize_t, lbound as ssize_t, 
 
 declare function fb_ArraySngBoundChk 	FBCALL ( sidx as size_t, ubound as size_t,linenum as long, fname as const ubyte ptr ) as any ptr
 
-declare sub 	 fb_hArrayCtorObj 			   ( array as FBARRAY ptr, ctor as FB_DEFCTOR, base_idx as size_t )
-declare sub 	 fb_hArrayDtorObj 			   ( array as FBARRAY ptr, dtor as FB_DEFCTOR, base_idx as size_t )
-declare sub 	 fb_hArrayDtorStr 			   ( array as FBARRAY ptr, dtor as FB_DEFCTOR, base_idx as size_t )
+declare function fb_ArrayLen            FBCALL ( array as FBARRAY ptr ) as size_t
+declare function fb_ArraySize           FBCALL ( array as FBARRAY ptr ) as size_t
+declare sub 	 fb_hArrayCtorObj 			   ( array as FBARRAY ptr, ctor as FB_DEFCTOR )
+declare sub 	 fb_hArrayDtorObj 			   ( array as FBARRAY ptr, dtor as FB_DEFCTOR, keep_idx as size_t )
+declare sub 	 fb_hArrayDtorStr 			   ( array as FBARRAY ptr, dtor as FB_DEFCTOR, heep_idx as size_t )
 declare sub 	 fb_ArrayDestructObj 	FBCALL ( array as FBARRAY ptr, dtor as FB_DEFCTOR )
 declare sub 	 fb_ArrayDestructStr 	FBCALL ( array as FBARRAY ptr )
 declare function fb_ArrayClear 			FBCALL ( array as FBARRAY ptr ) as long

--- a/fb_thread.bi
+++ b/fb_thread.bi
@@ -4,29 +4,29 @@
 
 type FB_THREADPROC as sub FBCALL( param as any ptr )
 
-type FBTHREAD As _FBTHREAD
+type FBTHREAD as _FBTHREAD
 
 type FBMUTEX as _FBMUTEX
 
 type FBCOND as _FBCOND
 
 extern "C"
-declare function fb_ThreadCreate 		FBCALL ( proc as FB_THREADPROC, param as any ptr, stack_size as ssize_t ) as FBTHREAD ptr
-declare function fb_ThreadSelf			FBCALL ( ) as FBTHREAD ptr
-declare sub 	 fb_ThreadWait 			FBCALL ( thread as FBTHREAD ptr )
-declare sub 	 fb_ThreadDetach 		FBCALL ( thread as FBTHREAD ptr )
+declare function fb_ThreadCreate 		FBCALL ( byval proc as FB_THREADPROC, byval param as any ptr, byval stack_size as ssize_t ) as FBTHREAD ptr
+declare function fb_ThreadSelf          FBCALL ( ) as FBTHREAD ptr
+declare sub 	 fb_ThreadWait 			FBCALL ( byval thread as FBTHREAD ptr )
+declare sub 	 fb_ThreadDetach 		FBCALL ( byval thread as FBTHREAD ptr )
 
-declare function fb_ThreadCall 			       ( proc as any ptr, abi as long, stack_size as ssize_t, num_args as long, ... ) as FBTHREAD ptr
+declare function fb_ThreadCall 			       ( byval proc as any ptr, byval abi as long, byval stack_size as ssize_t, byval num_args as long, ... ) as FBTHREAD ptr
 
 declare function fb_MutexCreate 		FBCALL ( ) as FBMUTEX ptr
-declare sub 	 fb_MutexDestroy 		FBCALL ( mutex as FBMUTEX ptr )
-declare sub 	 fb_MutexLock 			FBCALL ( mutex as FBMUTEX ptr )
-declare sub 	 fb_MutexUnlock 		FBCALL ( mutex as FBMUTEX ptr )
+declare sub 	 fb_MutexDestroy 		FBCALL ( byval mutex as FBMUTEX ptr )
+declare sub 	 fb_MutexLock 			FBCALL ( byval mutex as FBMUTEX ptr )
+declare sub 	 fb_MutexUnlock 		FBCALL ( byval mutex as FBMUTEX ptr )
 
 declare function fb_CondCreate 			FBCALL ( ) as FBCOND ptr
-declare sub 	 fb_CondDestroy 		FBCALL ( cond as FBCOND ptr )
-declare sub 	 fb_CondSignal 			FBCALL ( cond as FBCOND ptr )
-declare sub 	 fb_CondBroadcast 		FBCALL ( cond as FBCOND ptr )
-declare sub 	 fb_CondWait 			FBCALL ( cond as FBCOND ptr, mutex as FBMUTEX ptr )
+declare sub 	 fb_CondDestroy 		FBCALL ( byval cond as FBCOND ptr )
+declare sub 	 fb_CondSignal 			FBCALL ( byval cond as FBCOND ptr )
+declare sub 	 fb_CondBroadcast 		FBCALL ( byval cond as FBCOND ptr )
+declare sub 	 fb_CondWait 			FBCALL ( byval cond as FBCOND ptr, mutex as FBMUTEX ptr )
 
 end extern

--- a/sys_mkdir.bas
+++ b/sys_mkdir.bas
@@ -9,9 +9,9 @@ function fb_MkDir FBCALL ( path as FBSTRING ptr ) as long
 	dim as long res
 
 #ifdef HOST_WIN32
-	res = _mkdir( path->data );
+	res = _mkdir( path->data )
 #else
-	res = _mkdir( path->data, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH );
+	res = _mkdir( path->data, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH )
 #endif
 
 	/' del if temp '/

--- a/thread_obj.bas
+++ b/thread_obj.bas
@@ -20,12 +20,12 @@ Destructor _FBTHREAD( )
 End Destructor
 
 Function _FBTHREAD.GetData ( ByVal key as Ulong ) As Any Ptr
-    Assert( key < UBound( this.tlsData ) )
+    Assert( key <= UBound( this.tlsData ) ) '' alternate: (key < FB_TLSKEYS)
     Return this.tlsData( key ).slotData
 End Function
 
 Sub _FBTHREAD.SetData ( ByVal key As Ulong, ByVal slotData As Any Ptr, ByVal destroyer As FBTlsDestroyer )
-    Assert( key < UBound(this.tlsData) )
+    Assert( key <= UBound(this.tlsData) ) '' alternate: (key < FB_TLSKEYS)
     Dim cell As FBTlsDataCell Ptr = @this.tlsData(key)
     If( cell->destroyer <> 0 ) Then
         cell->destroyer( cell->slotData )


### PR DESCRIPTION
Synchronize with changes in freebasic/fbc:

- rtlib: sf.net # 950: REDIM PRESERVE does not destroy the correct array elements
- see https://sourceforge.net/p/fbc/bugs/950/
- see https://github.com/freebasic/fbc/commit/7fa0729f10265f43d4edbde4d53cb18ed78d1bd0
- the changes are made with respect to fbc 1.09.0, however the library API is still compatible so should also be also usable with fbc 1.08.x

Plus, some minor typos and fix-ups after PR #17 .

Worked for me: with these changes, fbc-1.09 unit-tests will run for win32 and win64 with some failures in string formatting.  (plus, a few tests in threads/self.bas had to be disabled but only when running the debug version of fbrtlib - the test-suite checks that thread detach should have no affect on the main thread but the rtlib throws an assert in the debug version if the operation is attempted.)