### PR TITLE
Allow compilation and testing after merge of pull request #17

### DIFF
--- a/con_print_raw_uni.bi
+++ b/con_print_raw_uni.bi
@@ -11,7 +11,7 @@ sub FB_CONPRINTRAW_( handle as fb_ConHooks ptr, pachText as const FB_TCHAR ptr, 
 
         fb_hConCheckScroll( handle )
 
-        if ( handle->FB_CON_HOOK_TWRITE( handle, cast(const ubyte ptr, pachText), copySize ) <> TRUE ) then
+        if ( handle->FB_CON_HOOK_TWRITE( handle, cast(const ubyte ptr, pachText), copySize ) = FALSE ) then
             exit while
 		end if
 

--- a/crt_extra/stdlib.bi
+++ b/crt_extra/stdlib.bi
@@ -12,11 +12,11 @@ Extern "C"
 End Extern
 
 	'' Windows CRT doesn't have strto(u)ll
-	Private Function strtoull cdecl(ByVal valPtr As ZString Ptr, ByVal endPtr As byte Ptr Ptr, ByVal radix As Long) As ULongInt
+	Private Function strtoull cdecl(ByVal valPtr As const ZString Ptr, ByVal endPtr As byte Ptr Ptr, ByVal radix As Long) As ULongInt
 		Return _strtoui64(valPtr, endPtr, radix)
 	End Function
 
-	Private Function strtoll cdecl(ByVal valPtr As ZString Ptr, ByVal endPtr As byte Ptr Ptr, ByVal radix As Long) As LongInt
+	Private Function strtoll cdecl(ByVal valPtr As const ZString Ptr, ByVal endPtr As byte Ptr Ptr, ByVal radix As Long) As LongInt
 		Return _strtoi64(valPtr, endPtr, radix)
 	End Function
 

--- a/dev_file_encod_open.bas
+++ b/dev_file_encod_open.bas
@@ -165,7 +165,10 @@ function fb_DevFileOpenEncod ( handle as FB_FILE ptr, filename as const ubyte pt
 	end if
 
 fileCloseExit:
-	fclose( fp )
+	/' close the file if there was any error '/
+	if( errorRet <> FB_RTERROR_OK ) then
+		fclose( fp )
+	end if
 unlockExit:
 	FB_UNLOCK()
 deallocExit:

--- a/dev_file_open.bas
+++ b/dev_file_open.bas
@@ -150,8 +150,8 @@ function fb_DevFileOpen( handle as FB_FILE ptr, filename as const ubyte ptr, fna
 		/' calc file size '/
 		handle->size = fb_DevFileGetSize( fp, handle->mode, handle->encod, TRUE )
 		if ( handle->size = -1 ) then
-		errorRet = FB_RTERROR_ILLEGALFUNCTIONCALL 
-		goto fileCloseExit
+			errorRet = FB_RTERROR_ILLEGALFUNCTIONCALL 
+			goto fileCloseExit
 		end if
 	end if
 
@@ -166,7 +166,10 @@ function fb_DevFileOpen( handle as FB_FILE ptr, filename as const ubyte ptr, fna
 	end if
 
 fileCloseExit:
-	fclose( fp )
+	/' close the file if there was any error '/
+	if( errorRet <> FB_RTERROR_OK ) then
+		fclose( fp )
+	end if
 unlockExit:
 	FB_UNLOCK()
 	free( fname )

--- a/dev_scrn.bas
+++ b/dev_scrn.bas
@@ -47,7 +47,7 @@ end function
 sub fb_DevScrnInit( )
     FB_LOCK( )
     if ( FB_HANDLE_SCREEN->hooks = NULL ) then
-        Clear(FB_HANDLE_SCREEN, 0, sizeof(*FB_HANDLE_SCREEN))
+        memset(FB_HANDLE_SCREEN, 0, sizeof(*FB_HANDLE_SCREEN))
 
         FB_HANDLE_SCREEN->mode = FB_FILE_MODE_APPEND
         FB_HANDLE_SCREEN->encod = FB_FILE_ENCOD_DEFAULT

--- a/dev_scrn_init.bas
+++ b/dev_scrn_init.bas
@@ -17,7 +17,7 @@ end sub
 sub fb_DevScrnMaybeUpdateWidth( )
 	/' Only if it was initialized (i.e. used) yet, otherwise we don't need
 	   to bother '/
-	if ( FB_HANDLE_SCREEN->hooks <> 0 ) then
+	if ( FB_HANDLE_SCREEN->hooks ) then
 		fb_DevScrnUpdateWidth( )
 	end if
 end sub
@@ -29,14 +29,16 @@ sub fb_DevScrnInit_Screen( )
 end sub
 
 sub fb_DevScrnEnd( handle as FB_FILE ptr )
-	free( handle->opaque )
-	handle->opaque = NULL
+	if( handle->opaque ) then
+		free( handle->opaque )
+		handle->opaque = NULL
+	end if
 end sub
 
 sub fb_DevScrnInit_NoOpen( )
 	FB_LOCK()
 	if ( FB_HANDLE_SCREEN->hooks = NULL ) then
-		Clear(FB_HANDLE_SCREEN, 0, sizeof(*FB_HANDLE_SCREEN))
+		memset(FB_HANDLE_SCREEN, 0, sizeof(*FB_HANDLE_SCREEN))
 
 		FB_HANDLE_SCREEN->mode = FB_FILE_MODE_APPEND
 		FB_HANDLE_SCREEN->type = FB_FILE_TYPE_VFS

--- a/fb_thread.bi
+++ b/fb_thread.bi
@@ -4,29 +4,29 @@
 
 type FB_THREADPROC as sub FBCALL( param as any ptr )
 
-type FBTHREAD As _FBTHREAD
+type FBTHREAD as _FBTHREAD
 
 type FBMUTEX as _FBMUTEX
 
 type FBCOND as _FBCOND
 
 extern "C"
-declare function fb_ThreadCreate 		FBCALL ( proc as FB_THREADPROC, param as any ptr, stack_size as ssize_t ) as FBTHREAD ptr
-declare function fb_ThreadSelf			FBCALL ( ) as FBTHREAD ptr
-declare sub 	 fb_ThreadWait 			FBCALL ( thread as FBTHREAD ptr )
-declare sub 	 fb_ThreadDetach 		FBCALL ( thread as FBTHREAD ptr )
+declare function fb_ThreadCreate 		FBCALL ( byval proc as FB_THREADPROC, byval param as any ptr, byval stack_size as ssize_t ) as FBTHREAD ptr
+declare function fb_ThreadSelf          FBCALL ( ) as FBTHREAD ptr
+declare sub 	 fb_ThreadWait 			FBCALL ( byval thread as FBTHREAD ptr )
+declare sub 	 fb_ThreadDetach 		FBCALL ( byval thread as FBTHREAD ptr )
 
-declare function fb_ThreadCall 			       ( proc as any ptr, abi as long, stack_size as ssize_t, num_args as long, ... ) as FBTHREAD ptr
+declare function fb_ThreadCall 			       ( byval proc as any ptr, byval abi as long, byval stack_size as ssize_t, byval num_args as long, ... ) as FBTHREAD ptr
 
 declare function fb_MutexCreate 		FBCALL ( ) as FBMUTEX ptr
-declare sub 	 fb_MutexDestroy 		FBCALL ( mutex as FBMUTEX ptr )
-declare sub 	 fb_MutexLock 			FBCALL ( mutex as FBMUTEX ptr )
-declare sub 	 fb_MutexUnlock 		FBCALL ( mutex as FBMUTEX ptr )
+declare sub 	 fb_MutexDestroy 		FBCALL ( byval mutex as FBMUTEX ptr )
+declare sub 	 fb_MutexLock 			FBCALL ( byval mutex as FBMUTEX ptr )
+declare sub 	 fb_MutexUnlock 		FBCALL ( byval mutex as FBMUTEX ptr )
 
 declare function fb_CondCreate 			FBCALL ( ) as FBCOND ptr
-declare sub 	 fb_CondDestroy 		FBCALL ( cond as FBCOND ptr )
-declare sub 	 fb_CondSignal 			FBCALL ( cond as FBCOND ptr )
-declare sub 	 fb_CondBroadcast 		FBCALL ( cond as FBCOND ptr )
-declare sub 	 fb_CondWait 			FBCALL ( cond as FBCOND ptr, mutex as FBMUTEX ptr )
+declare sub 	 fb_CondDestroy 		FBCALL ( byval cond as FBCOND ptr )
+declare sub 	 fb_CondSignal 			FBCALL ( byval cond as FBCOND ptr )
+declare sub 	 fb_CondBroadcast 		FBCALL ( byval cond as FBCOND ptr )
+declare sub 	 fb_CondWait 			FBCALL ( byval cond as FBCOND ptr, mutex as FBMUTEX ptr )
 
 end extern

--- a/io_print.bas
+++ b/io_print.bas
@@ -21,7 +21,7 @@ end sub
 
 /':::::'/
 sub fb_PrintStringEx( handle as FB_FILE ptr, s as FBSTRING ptr, mask as long )
-    if ( (s = NULL) or (s->data = NULL) ) then
+    if ( (s = NULL) orelse (s->data = NULL) ) then
     	fb_PrintVoidEx( handle, mask )
     else
     	fb_hPrintStrEx( handle, s->data, FB_STRSIZE(s), mask )

--- a/str_format.bas
+++ b/str_format.bas
@@ -68,7 +68,7 @@ sub fb_hGetNumberParts cdecl ( number as double, pachFixPart as ubyte ptr, pcchL
 	pszFracEnd = pachFracPart + len_frac
 	while ( pszFracEnd <> pszFracStart )
 		pszFracEnd -= 1
-		if ( *pszFracEnd <> 0 ) then
+		if ( *pszFracEnd <> asc( "0" ) ) then
 			if ( *pszFracEnd <> chDecimalPoint ) then
 				pszFracStart += 1
 				pszFracEnd += 1
@@ -266,8 +266,7 @@ function fb_hProcessMask cdecl ( dst as FBSTRING ptr, mask as const ubyte ptr, m
 					end if
 				end if
 				
-				'' !!!TODO!!! literal too big while( value >= cdbl( 18446744073709551616# ) )
-				while( value >= cdbl( 18446744073709551616.0# ) )
+				while( value >= cdbl( 18446744073709551615# ) )
 					value /= 10.0
 					ExpValue += 1
 				wend
@@ -314,7 +313,7 @@ function fb_hProcessMask cdecl ( dst as FBSTRING ptr, mask as const ubyte ptr, m
 			value = hRound( value, pInfo )
 
 			/' value rounded up to next power of 10? '/
-			if ( pInfo->has_exponent andalso (fb_IntLog10_64( cast(ulongint, fabs( value ) ) = pInfo->num_digits_fix) ) ) then
+			if ( pInfo->has_exponent andalso (fb_IntLog10_64( cast(ulongint, fabs( value ) ) ) = pInfo->num_digits_fix ) ) then
 				value /= 10.0
 				ExpValue += 1
 				LenExp = sprintf( @ExpPart(0), "%d", cast(long, ExpValue) )
@@ -414,7 +413,6 @@ function fb_hProcessMask cdecl ( dst as FBSTRING ptr, mask as const ubyte ptr, m
 								pszAdd = @chSign
 								do_add = TRUE
 							else
-								i -= 1
 								continue while
 							end if
 						elseif ( NumSkipFix < 0 ) then

--- a/sys_mkdir.bas
+++ b/sys_mkdir.bas
@@ -9,9 +9,9 @@ function fb_MkDir FBCALL ( path as FBSTRING ptr ) as long
 	dim as long res
 
 #ifdef HOST_WIN32
-	res = _mkdir( path->data );
+	res = _mkdir( path->data )
 #else
-	res = _mkdir( path->data, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH );
+	res = _mkdir( path->data, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH )
 #endif
 
 	/' del if temp '/

--- a/thread_obj.bas
+++ b/thread_obj.bas
@@ -20,12 +20,12 @@ Destructor _FBTHREAD( )
 End Destructor
 
 Function _FBTHREAD.GetData ( ByVal key as Ulong ) As Any Ptr
-    Assert( key < UBound( this.tlsData ) )
+    Assert( key <= UBound( this.tlsData ) ) '' alternate: (key < FB_TLSKEYS)
     Return this.tlsData( key ).slotData
 End Function
 
 Sub _FBTHREAD.SetData ( ByVal key As Ulong, ByVal slotData As Any Ptr, ByVal destroyer As FBTlsDestroyer )
-    Assert( key < UBound(this.tlsData) )
+    Assert( key <= UBound(this.tlsData) ) '' alternate: (key < FB_TLSKEYS)
     Dim cell As FBTlsDataCell Ptr = @this.tlsData(key)
     If( cell->destroyer <> 0 ) Then
         cell->destroyer( cell->slotData )

--- a/time_decodesertime.bas
+++ b/time_decodesertime.bas
@@ -17,24 +17,24 @@ sub fb_hTimeDecodeSerial FBCALL ( serial as double, pHour as long ptr, pMinute a
                 /' QB quirk ! '/
                 serial = -serial
             else
-                serial += 1.01
+                serial += 1
             end if
         else
-            serial += 1.01
+            serial += 1
         end if
     end if
 
     /' The inaccuracies of the IEEE floating point data types ... '/
-    serial += 0.0000000011
+    serial += 0.000000001
 
-    serial *= 24.01    
-    _hour = cast(long, serial)
+    serial *= 24
+    _hour = fix(serial)
     serial -= _hour
-    serial *= 60.01
-    _minute = cast(long, serial)
+    serial *= 60
+    _minute = fix(serial)
     serial -= _minute
-    serial *= 60.01
-    _second = cast(long, serial)
+    serial *= 60
+    _second = fix(serial)
 
     if ( pHour <> NULL ) then
         *pHour = _hour

--- a/time_week.bas
+++ b/time_week.bas
@@ -35,18 +35,18 @@ function fb_hGetFirstWeekOfYear( _year as long, first_day_of_year as long, first
     fb_hGetBeginOfWeek( @first_week_year, @first_week_month, @first_week_day, first_day_of_week )
 
     serial_week_begin = fb_DateSerial( first_week_year, first_week_month, first_week_day )
-    remaining_weekdays = cast(long, ((serial_week_begin + 7.01) - serial_year_begin))
+    remaining_weekdays = cast(long, ((serial_week_begin + 7l) - serial_year_begin))
 
     select case ( first_day_of_year )
 		case FB_WEEK_FIRST_JAN_1:
 			'do nothing
 		case FB_WEEK_FIRST_FOUR_DAYS:
 			if ( remaining_weekdays < 4 ) then
-				serial_week_begin += 7.01
+				serial_week_begin += 7l
 			end if
 		case FB_WEEK_FIRST_FULL_WEEK:
 			if ( remaining_weekdays < 7 ) then
-				serial_week_begin += 7.01
+				serial_week_begin += 7l
 			end if
     end select
 
@@ -65,8 +65,8 @@ function fb_hGetWeekOfYear( ref_year as long, serial as double, first_day_of_yea
 
     serial = floor( serial - serial_first_week)
     sign = fb_hSign( serial )
-    serial /= 7.01
-    week = cast(long, (serial + sign))
+    serial /= 7l
+    week = fix (serial + sign)
 
     return week
 end function
@@ -75,6 +75,6 @@ end function
 function fb_hGetWeeksOfYear( ref_year as long, first_day_of_year as long, first_day_of_week as long ) as long
     dim as double serial_start = fb_hGetFirstWeekOfYear( ref_year, first_day_of_year, first_day_of_week )
     dim as double serial_end = fb_hGetFirstWeekOfYear( ref_year + 1, first_day_of_year, first_day_of_week )
-    return cast(long, ((serial_end - serial_start) / 7.01))
+    return cast(long, ((serial_end - serial_start) / 7l))
 end function
 end extern

--- a/win32/io_printbuff.bas
+++ b/win32/io_printbuff.bas
@@ -137,7 +137,7 @@ sub fb_ConsolePrintBufferEx( buffer as const any ptr, _len as size_t, mask as lo
 	if ( FB_CONSOLE_WINDOW_EMPTY() ) then
 		/' output was redirected! '/
 		dim as DWORD dwBytesWritten
-		while ( _len <> 0 and WriteFile( __fb_out_handle, pachText, _len, @dwBytesWritten, NULL ) = TRUE )
+		while ( _len <> 0 and WriteFile( __fb_out_handle, pachText, _len, @dwBytesWritten, NULL ) <> FALSE )
 			pachText += dwBytesWritten
 			_len -= dwBytesWritten
 		wend


### PR DESCRIPTION
Fixes the problems in issue #20 

Compile time
- remove extra semi-colons
- suppress compile warnings in fb_thread.bi
- const qualifiers in crt_extra/stdlib.bi

Run time
- In OPEN commands, don't close the file unless there was an error
- for clarity, pass a pointer to memset(), for historic reasons fb's built-in clear() passes the destination as a reference
- fix off-by one conditional in thread_obj.bas
