### PR TITLE
Import changes from fbc/src/rtlib (fbc 1.09.0, 1.08.1 compatible)

### DIFF
--- a/array_clearobj.bas
+++ b/array_clearobj.bas
@@ -3,25 +3,15 @@
 #include "fb.bi"
 
 extern "C"
-sub fb_hArrayCtorObj( array as FBARRAY ptr, ctor as FB_DEFCTOR, base_idx as size_t )
-	dim as size_t i, elements, element_len
-	dim as FBARRAYDIM ptr _dim
+sub fb_hArrayCtorObj( array as FBARRAY ptr, ctor as FB_DEFCTOR )
+	dim as size_t elements, element_len
 	dim as ubyte ptr this_
 
 	if ( array->_ptr = NULL ) then
 		exit sub
 	end if
 	
-	_dim = @array->dimTB(0)
-	elements = _dim->elements - base_idx
-	_dim += 1
-
-	i = 1
-	while( i < array->dimensions )
-		elements *= _dim->elements
-		i += 1
-		_dim += 1
-	wend
+	elements = fb_ArrayLen( array )
 
 	/' call ctors '/
 	element_len = array->element_len
@@ -45,7 +35,7 @@ function fb_ArrayClearObj FBCALL ( array as FBARRAY ptr, ctor as FB_DEFCTOR, dto
 	/' re-initialize (ctor can be NULL if there only is a dtor) '/
 	if( ctor <> 0) then
 		/' if a ctor exists, it should handle the whole initialization '/
-		fb_hArrayCtorObj( array, ctor, 0 )
+		fb_hArrayCtorObj( array, ctor )
 	else
 		/' otherwise, just clear '/
 		fb_ArrayClear( array )

--- a/array_core.bas
+++ b/array_core.bas
@@ -3,6 +3,11 @@
 #include "fb.bi"
 
 extern "C"
+
+/' calculate the number of array elements based on the passed
+   in to fb_hArrayRealloc().  Note that this is a different
+   format than the arrary->dimTB[] table
+'/
 function fb_hArrayCalcElements ( dimensions as size_t, lboundTB as const ssize_t ptr, uboundTB as const ssize_t ptr ) as size_t
 	dim as size_t i, elements
 
@@ -35,4 +40,50 @@ function fb_hArrayCalcDiff ( dimensions as size_t, lboundTB as const ssize_t ptr
 
 	return -diff
 end function
+
+function fb_ArrayLen FBCALL ( array as FBARRAY ptr ) as size_t
+
+	if( array ) then
+		if( array->_ptr ) then
+			return array->size / array->element_len
+		end if
+	end if
+	
+	return 0
+
+/'
+
+	Previously, the number of elements was computed from
+	the array descriptor's dimensions table.
+
+	scope
+		dim as FBARRAYDIM ptr _dim
+	
+		_dim = @array->dimTB(0)
+		elements = _dim->elements
+		_dim += 1
+	
+		i = 1
+		while( i < array->dimensions )
+			elements *= _dim->elements
+			i += 1
+			_dim += 1
+		wend
+		
+		return elements
+	end scope
+
+'/
+end function
+
+function fb_ArraySize FBCALL ( array as FBARRAY ptr ) as size_t 
+	if( array ) then
+		if( array->_ptr ) then
+			return array->size
+		end if
+	end if
+	
+	return 0
+end function
+
 end extern

--- a/array_destructobj.bas
+++ b/array_destructobj.bas
@@ -3,31 +3,21 @@
 #include "fb.bi"
 
 extern "C"
-sub fb_hArrayDtorObj ( array as FBARRAY ptr, dtor as FB_DEFCTOR, base_idx as size_t )
-	dim as size_t i, elements, element_len
-	dim as FBARRAYDIM ptr _dim
+sub fb_hArrayDtorObj ( array as FBARRAY ptr, dtor as FB_DEFCTOR, keep_idx as size_t )
+	dim as size_t elements, element_len
 	dim as ubyte ptr this_
 
 	if ( array->_ptr = NULL ) then
 		exit sub
 	end if
 
-	_dim = @array->dimTB(0)
-	elements = _dim->elements - base_idx
-	_dim += 1
-
-	i = 1
-	while( i < array->dimensions )
-		elements *= _dim->elements
-		i += 1
-		_dim += 1
-	wend
+	elements = fb_ArrayLen( array )
 
 	/' call dtors in the inverse order '/
 	element_len = array->element_len
-	this_ = cast(ubyte ptr, (array->_ptr)) + ((base_idx + (elements - 1)) * element_len)
+	this_ = cast(ubyte ptr, (array->_ptr)) + ((elements - 1) * element_len)
 
-	while( elements > 0 )
+	while( elements > keep_idx )
 		/' !!!FIXME!!! check exceptions (only if rewritten in C++) '/
 		dtor( this_ )
 		this_ -= element_len

--- a/array_destructstr.bas
+++ b/array_destructstr.bas
@@ -3,31 +3,20 @@
 #include "fb.bi"
 
 extern "C"
-sub fb_hArrayDtorStr ( array as FBARRAY ptr, dtor as FB_DEFCTOR, base_idx as size_t )
-	dim as size_t i
-	dim as ssize_t elements
-	dim as FBARRAYDIM ptr _dim
+sub fb_hArrayDtorStr ( array as FBARRAY ptr, dtor as FB_DEFCTOR, keep_idx as size_t )
+	dim as size_t elements
 	dim as FBSTRING ptr this_
 
 	if ( array->_ptr = NULL ) then
 		exit sub
 	end if
 
-	_dim = @array->dimTB(0)
-	elements = _dim->elements - base_idx
-	_dim += 1
-
-	i = 1
-	while( i < array->dimensions )
-		elements *= _dim->elements
-		i += 1
-		_dim += 1
-	wend
+	elements = fb_ArrayLen( array )
 
 	/' call dtors in the inverse order '/
-	this_ = cast(FBSTRING ptr, array->_ptr) + (base_idx + (elements-1))
+	this_ = cast(FBSTRING ptr, array->_ptr) + (elements-1)
 
-	while( elements > 0 )
+	while( elements > keep_idx )
 		if ( this_->data <> NULL ) then
 			fb_StrDelete( this_ )
 		end if

--- a/array_redimpresv.bas
+++ b/array_redimpresv.bas
@@ -33,19 +33,18 @@ function fb_hArrayRealloc ( array as FBARRAY ptr, element_len as size_t, doclear
 		i += 1
 	wend
 
-	/' shrinking the array? free unused elements '/
-	if ( dtor_mult <> NULL ) then
-		dim as size_t new_lb = (ubTB(0) - lbTB(0)) + 1
-		if ( new_lb < array->dimTB(0).elements ) then
-			/' !!!FIXME!!! check exceptions (only if rewritten in C++) '/
-			dtor_mult( array, dtor, new_lb )
-		end if
-	end if
-
 	/' calc size '/
 	elements = fb_hArrayCalcElements( dimensions, @lbTB(0), @ubTB(0) )
 	diff = fb_hArrayCalcDiff( dimensions, @lbTB(0), @ubTB(0) ) * element_len
 	size = elements * element_len
+
+	/' shrinking the array? free unused elements '/
+	if ( dtor_mult <> NULL ) then
+		if ( elements < fb_ArrayLen( array ) ) then
+			/' !!!FIXME!!! check exceptions (only if rewritten in C++) '/
+			dtor_mult( array, dtor, elements )
+		end if
+	end if
 
 	/' realloc '/
 	array->_ptr = realloc( array->_ptr, size )

--- a/fb_array.bi
+++ b/fb_array.bi
@@ -49,9 +49,11 @@ declare function fb_ArrayBoundChk 		FBCALL ( idx as ssize_t, lbound as ssize_t, 
 
 declare function fb_ArraySngBoundChk 	FBCALL ( sidx as size_t, ubound as size_t,linenum as long, fname as const ubyte ptr ) as any ptr
 
-declare sub 	 fb_hArrayCtorObj 			   ( array as FBARRAY ptr, ctor as FB_DEFCTOR, base_idx as size_t )
-declare sub 	 fb_hArrayDtorObj 			   ( array as FBARRAY ptr, dtor as FB_DEFCTOR, base_idx as size_t )
-declare sub 	 fb_hArrayDtorStr 			   ( array as FBARRAY ptr, dtor as FB_DEFCTOR, base_idx as size_t )
+declare function fb_ArrayLen            FBCALL ( array as FBARRAY ptr ) as size_t
+declare function fb_ArraySize           FBCALL ( array as FBARRAY ptr ) as size_t
+declare sub 	 fb_hArrayCtorObj 			   ( array as FBARRAY ptr, ctor as FB_DEFCTOR )
+declare sub 	 fb_hArrayDtorObj 			   ( array as FBARRAY ptr, dtor as FB_DEFCTOR, keep_idx as size_t )
+declare sub 	 fb_hArrayDtorStr 			   ( array as FBARRAY ptr, dtor as FB_DEFCTOR, heep_idx as size_t )
 declare sub 	 fb_ArrayDestructObj 	FBCALL ( array as FBARRAY ptr, dtor as FB_DEFCTOR )
 declare sub 	 fb_ArrayDestructStr 	FBCALL ( array as FBARRAY ptr )
 declare function fb_ArrayClear 			FBCALL ( array as FBARRAY ptr ) as long


### PR DESCRIPTION
Synchronize with rtlib (C source) changes made in freebasic/fbc.

The intent here is that if bugs or changes are made to the C sources in freebasic/fbc, then port them over to fbrtLib so that we are not fixing the same bug later when fbrtLib is used.

- rtlib: sf.net # 950: REDIM PRESERVE does not destroy the correct array elements
- see https://sourceforge.net/p/fbc/bugs/950/
- see https://github.com/freebasic/fbc/commit/7fa0729f10265f43d4edbde4d53cb18ed78d1bd0
- the changes are made with respect to fbc 1.09.0, however the library API is still compatible so should also be also usable with fbc 1.08.x

Worked for me: with these changes, fbc-1.09 unit-tests will run for win32 and win64 with some failures in string formatting.  (plus, a few tests in threads/self.bas had to be disabled but only when running the debug version of fbrtlib - the test-suite checks that thread detach should have no affect on the main thread but the rtlib throws an assert in the debug version if the operation is attempted.)
