### PR TITLE
Import changes from fbc/src/rtlib (fbc 1.20.0 compatible)

### DIFF
--- a/dev_pipe_open.bas
+++ b/dev_pipe_open.bas
@@ -3,7 +3,7 @@
 #include "fb.bi"
 
 extern "C"
-#ifdef HOST_XBOX
+#if defined(HOST_XBOX) or defined(HOST_JS)
 
 function fb_DevPipeOpen( handle as FB_FILE ptr, filename as const ubyte ptr, filename_len ) as long
 	return fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL )

--- a/signals.bas
+++ b/signals.bas
@@ -1,5 +1,8 @@
 '' signal handlers
 
+'' Emscripten doesn't have signals
+#ifndef HOST_JS
+
 #include "fb.bi"
 #include "crt_extra/signal.bi"
 
@@ -84,3 +87,5 @@ Sub fb_InitSignals FBCALL ( )
 #endif
 End Sub
 End Extern
+
+#endif

--- a/str_core.bas
+++ b/str_core.bas
@@ -95,7 +95,8 @@ function fb_hStrRealloc FBCALL ( _str as FBSTRING ptr, size as ssize_t, _preserv
 	/' plus 12.5% more '/
 	newsize += (newsize shr 3)
 
-	if ( (_str->data = NULL) orelse (size > _str->size) orelse (newsize < (_str->size - (_str->size shr 3))) ) then
+	if ( (_str->data = NULL) orelse (size > _str->size) orelse _
+	    ((_preserve = 0) andalso (newsize < (_str->size - (_str->size shr 3)))) ) then
 		if ( _preserve = FB_FALSE ) then
 			fb_StrDelete( _str )
 

--- a/str_left.bas
+++ b/str_left.bas
@@ -40,4 +40,40 @@ function fb_LEFT FBCALL ( src as FBSTRING ptr, chars as ssize_t ) as FBSTRING pt
 
 	return dst
 end function
+
+/' 
+	Special case of a = left( a, n )
+	The string 'a' is not reallocated, only the string length field is adjusted
+	and a NUL terminator written. fbc does not optimize for this so to use,
+	it must be a direct call by the user.  Careful, due the function declaration, it
+	does not check for fb_LEFTSELF( "literal", n ) so if src is a temporary,
+	it just gets deleted.
+'/
+sub fb_LEFTSELF FBCALL ( src as FBSTRING ptr, chars as ssize_t )
+	dim as ssize_t src_len
+
+	if ( src = NULL ) then
+		exit sub
+	end if
+
+	FB_STRLOCK()
+
+	src_len = FB_STRSIZE( src )
+	if( (src->data <> NULL)	andalso (chars >= 0) andalso (src_len >= 0) ) then
+		if( chars > src_len ) then
+			fb_hStrSetLength( src, src_len )
+			/' add a NUL character '/
+			src->data[src_len] = 0
+		else
+			fb_hStrSetLength( src, chars )
+			/' add a NUL character '/
+			src->data[chars] = 0
+		end if
+	end if
+
+	/' del if temp '/
+	fb_hStrDelTemp_NoLock( src )
+
+	FB_STRUNLOCK()
+end sub
 end extern

--- a/win32/fb_win32.bi
+++ b/win32/fb_win32.bi
@@ -13,6 +13,22 @@
 #define FB_BINARY_NEWLINE !"\r\n"
 #define FB_BINARY_NEWLINE_WSTR _LC(!"\r\n")
 
+#if defined( HOST_CYGWIN )
+	#define FB_LL_FMTMOD "ll"
+#else
+	/' ucrt and mingw-w64's implementation of printf format specifers
+	   require that long long use the 'll' specifier instead of 'I64' 
+	'/
+	#ifndef __USE_MINGW_ANSI_STDIO
+		#define __USE_MINGW_ANSI_STDIO 0
+	#endif
+	#if defined(_UCRT) orelse __USE_MINGW_ANSI_STDIO 
+		#define FB_LL_FMTMOD "ll"
+	#else
+		#define FB_LL_FMTMOD "I64"
+	#endif
+#endif
+
 #define FB_LL_FMTMOD "I64"
 
 #define FB_CONSOLE_MAXPAGES 4


### PR DESCRIPTION
Synchronize with rtlib (C source) changes made in freebasic/fbc.

fbc 1.20.0
rtlib: optimize string concatenation
- optimize string concatenation reallocations: do not reallocate to smaller memory buffer if the contents are to be preserved
