### PR TITLE
Import changes from fbc/src/rtlib (fbc 1.20.0 compatible - March 2024)

### DIFF
--- a/array_boundchk.bas
+++ b/array_boundchk.bas
@@ -3,7 +3,7 @@
 #include "fb.bi"
 
 extern "C"
-function hThrowError ( linenum as long, fname as const ubyte ptr ) as any ptr
+private function hThrowError ( linenum as long, fname as const ubyte ptr ) as any ptr
 	/' call user handler if any defined '/
    return cast(any ptr, fb_ErrorThrowEx( FB_RTERROR_OUTOFBOUNDS, linenum, fname, NULL, NULL ))
 end function

--- a/array_clear.bas
+++ b/array_clear.bas
@@ -12,6 +12,7 @@
    for plain arrays: fbc calls fb_ArrayClear()
    for object arrays: fbc calls fb_ArrayClearObj()
    for FBSTRING arrays: fbc calls fb_ArrayDestructStr()
+...for STRING*N arrays: fbc calls fb_ArrayFill()
 '/
 
 #include "fb.bi"
@@ -20,6 +21,14 @@ extern "C"
 function fb_ArrayClear FBCALL ( array as FBARRAY ptr ) as long
 	if ( array->_ptr ) then
 		memset( array->_ptr, 0, array->size )
+	end if
+
+	return fb_ErrorSetNum( FB_RTERROR_OK )
+end function
+
+function fb_ArrayFill FBCALL ( array as FBARRAY ptr, byval fillchar as long ) as long
+	if ( array->_ptr ) then
+		memset( array->_ptr, fillchar, array->size )
 	end if
 
 	return fb_ErrorSetNum( FB_RTERROR_OK )

--- a/array_redim.bas
+++ b/array_redim.bas
@@ -70,7 +70,10 @@ function fb_hArrayAlloc ( array as FBARRAY ptr, element_len as size_t, doclear a
 	/' Allocte new buffer '/
 	/' Clearing is not needed if not requested, or if ctors will be called
 	(ctors take care of clearing themselves) '/
-	if ( doclear <> 0 and (ctor = NULL) ) then
+	if ( (doclear = 32) and (ctor = NULL) ) then
+		array->_ptr = malloc( size )
+		memset( array->_ptr, 32, size )  
+	elseif ( (doclear <> 0) and (ctor = NULL) ) then
 		array->_ptr = calloc( size, 1 )
 	else
 		array->_ptr = malloc( size )

--- a/array_redimpresv.bas
+++ b/array_redimpresv.bas
@@ -68,6 +68,8 @@ function fb_hArrayRealloc ( array as FBARRAY ptr, element_len as size_t, doclear
 				this_ += element_len
 				objects -= 1
 			wend
+		elseif( doclear = 32 ) then
+			memset( cast(any ptr, this_), 32, size - array->size )
 		elseif ( doclear ) then
 			memset( cast(any ptr, this_), 0, size - array->size )
 		end if

--- a/fb_array.bi
+++ b/fb_array.bi
@@ -7,6 +7,7 @@
 	#undef fb_ArrayClearObj
 	#undef fb_ArrayErase
 	#undef fb_ArrayEraseObj
+	#undef fb_ArrayFill
 	#undef fb_ArrayStrErase
 	#undef fb_ArrayRedimEx
 	#undef fb_ArrayRedimObj
@@ -60,6 +61,7 @@ declare function fb_ArrayClear 			FBCALL ( array as FBARRAY ptr ) as long
 declare function fb_ArrayClearObj 		FBCALL ( array as FBARRAY ptr, ctor as FB_DEFCTOR, dtor as FB_DEFCTOR ) as long
 declare function fb_ArrayErase 			FBCALL ( array as FBARRAY ptr ) as long
 declare function fb_ArrayEraseObj 		FBCALL ( array as FBARRAY ptr, ctor as FB_DEFCTOR, dtor as FB_DEFCTOR ) as long
+declare function fb_ArrayFill           FBCALL ( array as FBARRAY ptr, byval fillchar as long ) as long
 declare function fb_ArrayGetDesc        FBCALL ( array as FBARRAY ptr ) as FBARRAY ptr
 declare sub 	 fb_ArrayStrErase 		FBCALL ( array as FBARRAY ptr )
 declare function fb_ArrayRedim 				   ( array as FBARRAY ptr, element_len as size_t, preserve as long, dimensions as size_t, ... ) as long

--- a/fb_string.bi
+++ b/fb_string.bi
@@ -110,13 +110,25 @@ extern "C"
  '/
 #ifdef HOST_64BIT
 	#define FB_TEMPSTRBIT (cast(longint, &h8000000000000000ll))
+#else
+	#define FB_TEMPSTRBIT (cast(long, &h80000000))
+#endif
+
+/' Flag to identify a string size as fixed length without a null terminator
+ *
+ * This flag is stored in in the ssize_t size parameter passed in to string 
+ * handling functions, use FB_STRSETUP_FIX)() and FB_STRSETUP_DYN() to query
+ * the string's length.
+ '/
+#ifdef HOST_64BIT
 	#define FB_STRISFIXED (cast(longint, &h8000000000000000ll))
 	#define FB_STRSIZEMSK (cast(longint, &h7fffffffffffffffll))
 #else
-	#define FB_TEMPSTRBIT (cast(long, &h80000000))
 	#define FB_STRISFIXED (cast(long, &h80000000))
 	#define FB_STRSIZEMSK (cast(long, &h7fffffff))
 #endif
+
+'' Value to identify string size as variable length
 #define FB_STRSIZEVARLEN -1
 
 /' Returns if the string is a temporary string.

--- a/fb_string.bi
+++ b/fb_string.bi
@@ -193,7 +193,7 @@ private sub fb_hStrSetLength( _str as FBSTRING ptr, size as size_t )
 	_str->len = size or (_str->len and FB_TEMPSTRBIT)
 end sub
 
-declare function fb_hStrAllocTmpDesc 		FBCALL ( ) as FBSTRING ptr
+declare function fb_hStrAllocTempDesc		FBCALL ( ) as FBSTRING ptr
 declare function fb_hStrDelTempDesc 		FBCALL ( str as FBSTRING ptr ) as long
 declare function fb_hStrAlloc 				FBCALL ( str as FBSTRING ptr, size as ssize_t ) as FBSTRING ptr
 declare function fb_hStrRealloc 			FBCALL ( str as FBSTRING ptr, size as ssize_t, _preserve as long ) as FBSTRING ptr

--- a/fb_string.bi
+++ b/fb_string.bi
@@ -45,6 +45,9 @@
 	#undef fb_TrimEx
 	#undef fb_TrimAny
 	#undef fb_StrLset
+	#undef fb_StrLsetANA
+	#undef fb_StrRset
+	#undef fb_StrRsetANA
 	#undef fb_StrLcase2
 	#undef fb_StrUcase2
 	#undef fb_StrFill1
@@ -88,6 +91,7 @@
 	#undef fb_WstrTrimEx
 	#undef fb_WstrTrimAny
 	#undef fb_WstrLset
+	#undef fb_WstrRset
 	#undef fb_WstrLcase2
 	#undef fb_WstrUcase2
 	#undef fb_WstrFill1
@@ -381,7 +385,9 @@ declare function fb_TRIM 					FBCALL ( src as FBSTRING ptr ) as FBSTRING ptr
 declare function fb_TrimEx 					FBCALL ( str as FBSTRING ptr, pattern as FBSTRING ptr ) as FBSTRING ptr
 declare function fb_TrimAny 				FBCALL ( str as FBSTRING ptr, pattern as FBSTRING ptr ) as FBSTRING ptr
 declare sub 	 fb_StrLset 				FBCALL ( dst as FBSTRING ptr, src as FBSTRING ptr )
+declare sub 	 fb_StrLsetANA 				FBCALL ( dst as any ptr, dst_size as ssize_t, src as FBSTRING ptr )
 declare sub 	 fb_StrRset 				FBCALL ( dst as FBSTRING ptr, src as FBSTRING ptr )
+declare sub 	 fb_StrRsetANA 				FBCALL ( dst as any ptr, dst_size as ssize_t, src as FBSTRING ptr )
 declare function fb_StrLcase2 				FBCALL ( src as FBSTRING ptr, mode as long ) as FBSTRING ptr
 declare function fb_StrUcase2 				FBCALL ( src as FBSTRING ptr, mode as long ) as FBSTRING ptr
 declare function fb_StrFill1 				FBCALL ( cnt as ssize_t, fchar as long ) as FBSTRING ptr

--- a/str_comp.bas
+++ b/str_comp.bas
@@ -51,10 +51,10 @@ function fb_StrCompare FBCALL ( str1 as any ptr, str1_size as ssize_t, str2 as a
 	FB_STRLOCK()
 
 	/' delete temps? '/
-	if ( str1_size = -1 ) then
+	if ( str1_size = FB_STRSIZEVARLEN ) then
 		fb_hStrDelTemp_NoLock( cast(FBSTRING ptr, str1) )
 	end if
-	if ( str2_size = -1 ) then
+	if ( str2_size = FB_STRSIZEVARLEN ) then
 		fb_hStrDelTemp_NoLock( cast(FBSTRING ptr, str2) )
 	end if
 

--- a/str_concatbyref.bas
+++ b/str_concatbyref.bas
@@ -41,7 +41,7 @@ function fb_StrConcatByref FBCALL _
 	dim as ssize_t dst_len = any, src_len = any
 
 	/' dst should always be var-len string '/
-	DBG_ASSERT( dst_size = -1 )
+	DBG_ASSERT( dst_size = FB_STRSIZEVARLEN )
 
 	/' dst '/
 	FB_STRSETUP_FIX( dst, dst_size, dst_ptr, dst_len )
@@ -68,10 +68,10 @@ function fb_StrConcatByref FBCALL _
 		end if
 
 		/' delete temps? '/
-		if( dst_size = -1 ) then
+		if( dst_size = FB_STRSIZEVARLEN ) then
 			fb_hStrDelTemp_NoLock( cast( FBSTRING ptr, dst ) )
 		end if
-		if( src_size = -1 ) then
+		if( src_size = FB_STRSIZEVARLEN ) then
 			fb_hStrDelTemp_NoLock( cast( FBSTRING ptr, src ) )
 		end if
 

--- a/str_core.bas
+++ b/str_core.bas
@@ -20,7 +20,7 @@ Dim shared as FB_LIST tmpdsList = Type( 0, NULL, NULL, NULL )
 Dim shared as FB_STR_TMPDESC fb_tmpdsTB( 0 to FB_STR_TMPDESCRIPTORS - 1)
 
 extern "C"
-function fb_hStrAllocTmpDesc FBCALL ( ) as FBSTRING ptr
+function fb_hStrAllocTempDesc FBCALL ( ) as FBSTRING ptr
 	dim as FB_STR_TMPDESC ptr dsc
 
 	if ( (tmpdsList.fhead = NULL) andalso (tmpdsList.head = NULL) ) then
@@ -139,7 +139,7 @@ function fb_hStrAllocTemp_NoLock FBCALL ( _str as FBSTRING ptr, size as ssize_t 
 	dim as long try_alloc = (_str = NULL)
 
     if ( try_alloc ) then
-        _str = fb_hStrAllocTmpDesc( )
+        _str = fb_hStrAllocTempDesc( )
         if ( _str=NULL ) then
             return NULL
 		end if

--- a/str_core.bas
+++ b/str_core.bas
@@ -107,22 +107,22 @@ function fb_hStrRealloc FBCALL ( _str as FBSTRING ptr, size as ssize_t, _preserv
 				newsize = size
 			end if
 		else
-            dim as ubyte ptr pszOld = _str->data
-			_str->data = ReAllocate( pszOld, newsize + 1 )
+			dim as byte ptr newbuffer = any
+			newbuffer = ReAllocate( _str->data, newsize + 1 )
+
 			/' failed? try the original request '/
-			if ( _str->data = NULL ) then
-				_str->data = ReAllocate( pszOld, size + 1 )
+			if ( newbuffer = NULL ) then
 				newsize = size
-                if ( _str->data = NULL ) then
-                    /' restore the old memory block '/
-                    _str->data = pszOld
-                    return NULL
-                end if
-            end if
+				newbuffer = ReAllocate( _str->data, size + 1 )
+				if ( newbuffer = NULL ) then
+					return NULL
+				end if
+			end if
+			_str->data = newbuffer
 		end if
 
 		if ( _str->data = NULL ) then
-            _str->len = 0
+			_str->len = 0
 			_str->size = 0
 			return NULL
 		end if
@@ -132,7 +132,7 @@ function fb_hStrRealloc FBCALL ( _str as FBSTRING ptr, size as ssize_t, _preserv
 
 	fb_hStrSetLength( _str, size )
 
-    return _str
+	return _str
 end function
 
 function fb_hStrAllocTemp_NoLock FBCALL ( _str as FBSTRING ptr, size as ssize_t ) as FBSTRING ptr

--- a/str_core.bas
+++ b/str_core.bas
@@ -202,5 +202,12 @@ sub fb_hStrCopy FBCALL ( dst as ubyte ptr, src as const ubyte ptr, bytes as ssiz
 
 	/' add the null-term '/
 	*dst = asc(!"\000") '' NUL CHAR
+
+end sub
+
+sub fb_hStrCopyN FBCALL ( dst as ubyte ptr, src as const ubyte ptr, bytes as ssize_t )
+	if ( (src <> NULL) and (bytes > 0) ) then
+		dst = cast(ubyte ptr, FB_MEMCPYX( dst, src, bytes ))
+	end if
 end sub
 end extern

--- a/str_left.bas
+++ b/str_left.bas
@@ -40,40 +40,4 @@ function fb_LEFT FBCALL ( src as FBSTRING ptr, chars as ssize_t ) as FBSTRING pt
 
 	return dst
 end function
-
-/' 
-	Special case of a = left( a, n )
-	The string 'a' is not reallocated, only the string length field is adjusted
-	and a NUL terminator written. fbc does not optimize for this so to use,
-	it must be a direct call by the user.  Careful, due the function declaration, it
-	does not check for fb_LEFTSELF( "literal", n ) so if src is a temporary,
-	it just gets deleted.
-'/
-sub fb_LEFTSELF FBCALL ( src as FBSTRING ptr, chars as ssize_t )
-	dim as ssize_t src_len
-
-	if ( src = NULL ) then
-		exit sub
-	end if
-
-	FB_STRLOCK()
-
-	src_len = FB_STRSIZE( src )
-	if( (src->data <> NULL)	andalso (chars >= 0) andalso (src_len >= 0) ) then
-		if( chars > src_len ) then
-			fb_hStrSetLength( src, src_len )
-			/' add a NUL character '/
-			src->data[src_len] = 0
-		else
-			fb_hStrSetLength( src, chars )
-			/' add a NUL character '/
-			src->data[chars] = 0
-		end if
-	end if
-
-	/' del if temp '/
-	fb_hStrDelTemp_NoLock( src )
-
-	FB_STRUNLOCK()
-end sub
 end extern

--- a/str_leftself.bas
+++ b/str_leftself.bas
@@ -1,0 +1,41 @@
+/' leftself statement '/
+
+#include "fb.bi"
+
+extern "C"
+/' 
+	Special case of a = left( a, n )
+	The string 'a' is not reallocated, only the string length field is adjusted
+	and a NUL terminator written. fbc does not optimize for this so to use,
+	it must be a direct call by the user.  Careful, due the function declaration, it
+	does not check for fb_LEFTSELF( "literal", n ) so if src is a temporary,
+	it just gets deleted.
+'/
+sub fb_LEFTSELF FBCALL ( src as FBSTRING ptr, chars as ssize_t )
+	dim as ssize_t src_len
+
+	if ( src = NULL ) then
+		exit sub
+	end if
+
+	FB_STRLOCK()
+
+	src_len = FB_STRSIZE( src )
+	if( (src->data <> NULL)	andalso (chars >= 0) andalso (src_len >= 0) ) then
+		if( chars > src_len ) then
+			fb_hStrSetLength( src, src_len )
+			/' add a NUL character '/
+			src->data[src_len] = 0
+		else
+			fb_hStrSetLength( src, chars )
+			/' add a NUL character '/
+			src->data[chars] = 0
+		end if
+	end if
+
+	/' del if temp '/
+	fb_hStrDelTemp_NoLock( src )
+
+	FB_STRUNLOCK()
+end sub
+end extern

--- a/str_len.bas
+++ b/str_len.bas
@@ -11,7 +11,7 @@ function fb_StrLen FBCALL ( _str as any ptr, str_size as ssize_t ) as ssize_t
 	end if
 
 	/' is dst var-len? '/
-	if ( str_size = -1 ) then
+	if ( str_size = FB_STRSIZEVARLEN ) then
 		_len = FB_STRSIZE( _str )
 
 		/' delete temp? '/

--- a/str_set.bas
+++ b/str_set.bas
@@ -11,7 +11,7 @@ sub fb_StrLset FBCALL ( dst as FBSTRING ptr, src as FBSTRING ptr )
 		dlen = FB_STRSIZE( dst )
 
 		if ( dlen > 0 ) then
-			_len = iif(dlen <= slen, dlen, slen )
+			_len = iif( dlen <= slen, dlen, slen )
 
 			fb_hStrCopy( dst->data, src->data, _len )
 
@@ -32,6 +32,30 @@ sub fb_StrLset FBCALL ( dst as FBSTRING ptr, src as FBSTRING ptr )
 	fb_hStrDelTemp( dst )
 end sub
 
+'' LSET fixed length string from var-len string
+sub fb_StrLsetANA ( dst as any ptr, dst_size as ssize_t, src as FBSTRING ptr )
+	dim as ssize_t slen = any, dlen = any, _len = any
+
+	if( (dst <> NULL) andalso (src <> NULL) ) then
+		slen = FB_STRSIZE( src )
+		dlen = dst_size and FB_STRSIZEMSK
+
+		if( dlen > 0 ) then
+			_len = iif (dlen <= slen, dlen, slen )
+
+			fb_hStrCopyN( dst, src->data, _len )
+
+			_len = dlen - slen
+			if( _len > 0 ) then
+				memset( dst + slen, 32, _len )
+			end if
+		end if
+	end if
+
+	/' del if temp '/
+	fb_hStrDelTemp( src )
+end sub
+
 sub fb_StrRset FBCALL ( dst as FBSTRING ptr, src as FBSTRING ptr )
 	dim as ssize_t slen, dlen, _len, padlen
 
@@ -47,7 +71,7 @@ sub fb_StrRset FBCALL ( dst as FBSTRING ptr, src as FBSTRING ptr )
 				padlen = 0
 			end if
 
-			_len = iif(dlen <= slen, dlen, slen )
+			_len = iif( dlen <= slen, dlen, slen )
 
 			fb_hStrCopy( @dst->data[padlen], src->data, _len )
 		end if
@@ -58,5 +82,31 @@ sub fb_StrRset FBCALL ( dst as FBSTRING ptr, src as FBSTRING ptr )
 
 	/' del if temp '/
 	fb_hStrDelTemp( dst )
+end sub
+
+'' RSET fixed length string from var-len string
+sub fb_StrRsetANA ( dst as any ptr, dst_size as ssize_t, src as FBSTRING ptr )
+	dim as ssize_t slen = any, dlen = any, _len = any, padlen = any
+
+	if( (dst <> NULL) andalso (src <> NULL) ) then
+		slen = FB_STRSIZE( src )
+		dlen = dst_size and FB_STRSIZEMSK
+
+		if( dlen > 0 ) then
+			padlen = dlen - slen
+			if( padlen > 0 ) then
+				memset( dst, 32, padlen )
+			else
+				padlen = 0
+			end if
+
+			_len = iif( dlen <= slen, dlen, slen )
+
+			fb_hStrCopyN( dst + padlen, src->data, _len )
+		end if
+	end if
+
+	/' del if temp '/
+	fb_hStrDelTemp( src )
 end sub
 end extern

--- a/str_tempdescf.bas
+++ b/str_tempdescf.bas
@@ -9,7 +9,7 @@ function fb_StrAllocTempDescF FBCALL ( _str as ubyte ptr, str_size as ssize_t ) 
 	FB_STRLOCK()
 
 	/' alloc a temporary descriptor '/
-	dsc = fb_hStrAllocTmpDesc( )
+	dsc = fb_hStrAllocTempDesc( )
 
 	FB_STRUNLOCK()
 

--- a/str_tempdescf.bas
+++ b/str_tempdescf.bas
@@ -20,8 +20,11 @@ function fb_StrAllocTempDescF FBCALL ( _str as ubyte ptr, str_size as ssize_t ) 
 	dsc->data = _str
 
 	/' can't use strlen() if the size is known '/
-	if ( str_size <> 0 ) then
-		dsc->len = str_size - 1			/' less the null-term '/
+	if ( str_size > 0 ) then
+		/' less the null-term '/
+		dsc->len = str_size - 1
+	elseif( str_size and FB_STRISFIXED ) then
+		dsc->len = str_size and FB_STRSIZEMSK
 	else
 		if ( _str <> NULL ) then
 			dsc->len = strlen( _str )

--- a/str_tempdescv.bas
+++ b/str_tempdescv.bas
@@ -9,7 +9,7 @@ function fb_StrAllocTempDescV FBCALL ( _str as FBSTRING ptr ) as FBSTRING ptr
 	FB_STRLOCK()
 
 	/' alloc a temporary descriptor '/
-	dsc = fb_hStrAllocTmpDesc( )
+	dsc = fb_hStrAllocTempDesc( )
 
 	FB_STRUNLOCK()
 

--- a/str_tempdescz.bas
+++ b/str_tempdescz.bas
@@ -9,7 +9,7 @@ function fb_StrAllocTempDescZEx FBCALL ( _str as const ubyte ptr, _len as ssize_
 	FB_STRLOCK()
 
 	/' alloc a temporary descriptor '/
-	dsc = fb_hStrAllocTmpDesc( )
+	dsc = fb_hStrAllocTempDesc( )
 
 	FB_STRUNLOCK()
 

--- a/str_tempres.bas
+++ b/str_tempres.bas
@@ -10,7 +10,7 @@ function fb_StrAllocTempResult FBCALL ( src as FBSTRING ptr ) as FBSTRING ptr
 	FB_STRLOCK()
 
 	/' alloc a temporary descriptor (the current one at stack will be trashed) '/
-	dsc = fb_hStrAllocTmpDesc( )
+	dsc = fb_hStrAllocTempDesc( )
 	if ( dsc = NULL ) then
 		FB_STRUNLOCK()
 		return @__fb_ctx.null_desc

--- a/strw_convconcat.bas
+++ b/strw_convconcat.bas
@@ -29,7 +29,7 @@ function fb_WstrConcatWA FBCALL ( str1 as const FB_WCHAR ptr, str2 as const any 
     end if
 
 	/' delete temp? '/
-	if ( str2_size = -1 ) then
+	if ( str2_size = FB_STRSIZEVARLEN ) then
 		fb_hStrDelTemp( cast(FBSTRING ptr, str2) )
 	end if
 
@@ -64,7 +64,7 @@ function fb_WstrConcatAW FBCALL ( str1 as const any ptr, str1_size as ssize_t, s
     end if
 
 	/' delete temp? '/
-	if ( str1_size = -1 ) then
+	if ( str1_size = FB_STRSIZEVARLEN ) then
 		fb_hStrDelTemp( cast(FBSTRING ptr, str1) )
 	end if
 

--- a/win32/fb_private_console.bi
+++ b/win32/fb_private_console.bi
@@ -42,6 +42,7 @@ declare sub 	 fb_hConsoleResetHandles 			   ( )
 declare function fb_ConsoleGetRawX 					   ( ) as long
 declare function fb_ConsoleGetRawY 					   ( ) as long
 declare function fb_hConsoleCreateBuffer 			   ( ) as HANDLE
+declare function fb_ConsoleHasFocus                    ( ) as long
 end extern
 
 #define __fb_in_handle  fb_hConsoleGetHandle( TRUE )

--- a/win32/io_input.bas
+++ b/win32/io_input.bas
@@ -16,6 +16,7 @@ dim shared as size_t key_head = 0, key_tail = 0
 dim shared as INPUT_RECORD input_events(0 to KEY_BUFFER_LEN - 1)
 dim shared as ulong key_scratch_pad = 0
 dim shared as long key_buffer_changed = FALSE
+dim shared as long console_has_focus = TRUE
 
 type FB_KEY_CODES
 	as ushort value_normal
@@ -343,6 +344,11 @@ private sub fb_hInitControlHandler( )
 end sub
 
 extern "c"
+
+function fb_ConsoleHasFocus( ) as long
+	return console_has_focus
+end function
+
 function fb_ConsoleProcessEvents( ) as long
 	dim as long got_event = FALSE
 	dim as INPUT_RECORD ir
@@ -376,6 +382,10 @@ function fb_ConsoleProcessEvents( ) as long
 						__fb_con.mouseEventHook( @ir.Event.MouseEvent )
 						got_event = TRUE
 					end if
+
+				case FOCUS_EVENT:
+					console_has_focus = ir.Event.FocusEvent.bSetFocus
+
 			end select
 
 			FB_UNLOCK()


### PR DESCRIPTION
import changes from fbc/src/rtlib (fbc 1.20.0)

rtlib: fix copy / paste error in src/rtlib/str_core.c
- see https://sourceforge.net/p/fbc/code/ci/8d4d878ec87827d52ed7afbb07c786d43b0883c8

rtlib: win32/win64: MULTIKEY() on consoles track console focus
- see https://sourceforge.net/p/fbc/code/ci/dfab9a84be9f9112b281dd5ecbb10bc6375a3290

rtlib: win32/win64: MULTIKEY() always returns true
- MULTIKEY(): don't call GetAsyncKeyState(0)
- see https://sourceforge.net/p/fbc/code/ci/63ccb9379f46405f1cff182a815fcf7f47fb5e80

fbc: string*n
- STRING*N occupies N bytes and has no terminating null character
- see https://sourceforge.net/p/fbc/code/ci/e5399443f7b316b1a5589a0096aac3c449004493
- initialize new elements to spaces, erase static arrays with spaces
- see  https://sourceforge.net/p/fbc/code/ci/da8f14569e2786e11b3e66371f39ecf306da3663
- LSET/RSET
- see  https://sourceforge.net/p/fbc/code/ci/e2cddccb0e5e25944e18a85e6d75647e2dc40e31

rtlib: cleanup
- split LEFT() and LEFTSELF() to separate files
- fix commenting for string flags
- fbrt: add missing 'private' on hThrowError()
- internal: normalize 'AllocTemp' procedure names
