### PR TITLE
Allow fb_CpuDetect to be compiled with debug information

### DIFF
--- a/x86/cpudetect.bas
+++ b/x86/cpudetect.bas
@@ -2,24 +2,22 @@
 
 #include "../fb_config.bi"
 
+'' Remove fbc's intrinsic definition
+'' of declare function fb_CpuDetect cdecl( ) as ulong
+#undef fb_CpuDetect
+
+extern "c"
+	declare function fb_CpuDetect naked () as ulong
+
+	/' bits  0-27: low 24 bits of feature flags (CPUID eax = 1, edx) '/
+	/' bits 28-31: cpu family (3 = 386, 4 = 486, 5 = 586, 6 = 686) '/
+
+	dim shared detected_cpu as ulong = 0
+end extern
+
+function fb_CpuDetect naked () as ulong
+
 asm
-	.intel_syntax noprefix
-
-.data
-detected_cpu: .long 0  /' bits  0-27: low 24 bits of feature flags (CPUID eax = 1, edx) '/
-                       /' bits 28-31: cpu family (3 = 386, 4 = 486, 5 = 586, 6 = 686) '/
-
-.text
-
-/' unsigned int fb_CpuDetect(void); '/
-#if defined (HOST_DOS) or defined (HOST_WIN32) or defined (HOST_XBOX)
-.globl _fb_CpuDetect
-_fb_CpuDetect:
-#else
-.globl fb_CpuDetect
-fb_CpuDetect:
-#endif
-
 	mov eax, [detected_cpu]
 	or eax, eax
 	jz detect
@@ -86,3 +84,5 @@ cpudetect_exit:
 	pop	ebp
 	ret
 end asm
+
+end function


### PR DESCRIPTION
This is a fix to an issue I found when building the latest fbrtLib.

When x86/cpudetect.bas is compiled with debugging information, the asm directives setting code and data sections conflict with fbc also setting code and data sections for the debugging information in the emitted asm file.

```
fbc-win32.exe -e -m nomain -g  -maxerr 1 -c src/fbrt/x86/cpudetect.bas -o src/fbrt/obj/win32/cpudetect.o
src/fbrt/obj/win32/cpudetect.asm: Assembler messages:
src/fbrt/obj/win32/cpudetect.asm:52: Error: can't resolve .data - _fb_ctor__cpudetect
src/fbrt/obj/win32/cpudetect.asm:58: Error: can't resolve .data - _fb_ctor__cpudetect
```

Cause appears to be x86/cpudetect.bas compiled with debug information and source and fbc compiler both trying to assert what section is next (code or data) and they not working together.  The result is gnu assembler can't make sense of it.

This fix removes the asm directives from x86/cpudetect.bas and replaces them with equivalent fbc statements.  This hands over the responsibility of code and data section selection and symbol naming to the compiler.
