### PR TITLE
Import changes from fbc/src/rtlib (fbc 1.20.0 compatible - April 2025)

### DIFF
--- a/array_redim.bas
+++ b/array_redim.bas
@@ -6,8 +6,8 @@ function fb_hArrayAlloc ( array as FBARRAY ptr, element_len as size_t, doclear a
 	dim as size_t i, elements, size
 	dim as ssize_t diff
 	dim as FBARRAYDIM ptr _dim
-	dim as ssize_t lbTB(0 to FB_MAXDIMENSIONS - 1)
-	dim as ssize_t ubTB(0 to FB_MAXDIMENSIONS - 1)
+	dim as ssize_t lbTB(0 to FB_MAXDIMENSIONS - 1) = { 0 }
+	dim as ssize_t ubTB(0 to FB_MAXDIMENSIONS - 1) = { 0 }
 
 	/' fixed length? '/
 
@@ -69,7 +69,7 @@ function fb_hArrayAlloc ( array as FBARRAY ptr, element_len as size_t, doclear a
 
 	/' Allocte new buffer '/
 	/' Clearing is not needed if not requested, or if ctors will be called
-	(ctors take care of clearing themselves) '/
+	   (ctors take care of clearing themselves) '/
 	if ( (doclear = 32) and (ctor = NULL) ) then
 		array->_ptr = malloc( size )
 		memset( array->_ptr, 32, size )  

--- a/makefile
+++ b/makefile
@@ -206,6 +206,10 @@ ifndef FBTARGET
   FBTARGET := $(TARGET_OS)-$(TARGET_ARCH)
 endif
 
+ifeq ($(TARGET_OS),dos)
+  ALLCFLAGS += -DDISABLE_WCHAR
+endif
+
 ifeq ($(TARGET_OS),xbox)
   # Assume no libffi for now (does it work on Xbox?)
   ALLCFLAGS += -DDISABLE_FFI

--- a/profile.bas
+++ b/profile.bas
@@ -372,7 +372,11 @@ public function PROFILER_GLOBAL_create( ) as FB_PROFILER_GLOBAL ptr
 
 		time_( @rawtime )
 		ptm = localtime( @rawtime )
-		sprintf( fb_profiler->launch_time, !"%02d-%02d-%04d, %02d:%02d:%02d", 1+ptm->tm_mon, ptm->tm_mday, 1900+ptm->tm_year, ptm->tm_hour, ptm->tm_min, ptm->tm_sec )
+		snprintf( fb_profiler->launch_time, sizeof(fb_profiler->launch_time), _
+			!"%02d-%02d-%04d, %02d:%02d:%02d", _
+			clng((1+ptm->tm_mon)) mod 100u, clng(ptm->tm_mday) mod 100u, clng(1900+ptm->tm_year) mod 100u, _
+			clng(ptm->tm_hour) mod 100u, clng(ptm->tm_min) mod 100u, clng(ptm->tm_sec) mod 100u )
+		fb_profiler->launch_time[sizeof(fb_profiler->launch_time)-1] = 0
 	end if
 	return fb_profiler
 end function

--- a/profile.bas
+++ b/profile.bas
@@ -463,7 +463,7 @@ end function
 
 '':::::
 public function fb_ProfileGetOptions FBCALL () as long
-	dim as long options = any
+	dim as long options = 0
 
 	FB_PROFILE_LOCK()
 
@@ -478,7 +478,7 @@ end function
 
 '':::::
 public function fb_ProfileSetOptions FBCALL ( byval options as long ) as long
-	dim as long previous_options = any
+	dim as long previous_options = 0
 
 	FB_PROFILE_LOCK()
 

--- a/profile_calls.bas
+++ b/profile_calls.bas
@@ -26,6 +26,17 @@
 #include "crt/time.bi"
 #include "fb_private_thread.bi"
 
+/' choose a suitable 64-bit decimal printf specifier '/
+#if not defined(fmtlld)
+	#if defined(PRId64)
+		#define fmtlld PRId64
+	#elif defined(FB_LL_FMTMOD) 
+		#define fmtlld ("%12" + FB_LL_FMTMOD + "d")
+	#else
+		#define fmtlld "%12lld"
+	#endif
+#endif
+
 extern "C"
 
 '' procs
@@ -497,7 +508,7 @@ private sub hProfilerReportCallsProc _
 		pad_spaces( f, len_ )
 
 		if( (prof->global->options and PROFILE_OPTION_HIDE_COUNTS) = 0 ) then
-			len_ = 14 - fprintf( f, !"%12lld", parent_proc->local_count )
+			len_ = 14 - fprintf( f, fmtlld, parent_proc->local_count )
 			pad_spaces( f, len_ )
 		end if
 
@@ -519,7 +530,7 @@ private sub hProfilerReportCallsProc _
 			pad_spaces( f, len_ )
 
 			if( (prof->global->options and PROFILE_OPTION_HIDE_COUNTS) = 0 ) then
-				len_ = 14 - fprintf( f, !"%12lld", proc->local_count )
+				len_ = 14 - fprintf( f, fmtlld, proc->local_count )
 				pad_spaces( f, len_ )
 			end if
 
@@ -654,7 +665,7 @@ private sub hProfilerReportCallsGlobals _
 		pad_spaces( f, len_ )
 
 		if( (prof->global->options and PROFILE_OPTION_HIDE_COUNTS) = 0 ) then
-			len_ = 14 - fprintf( f, !"%12lld", proc->local_count )
+			len_ = 14 - fprintf( f, fmtlld, proc->local_count )
 			pad_spaces( f, len_ )
 		end if
 
@@ -853,7 +864,7 @@ private sub hProfilerReportRawList _
 			pad_spaces( f, len_ )
 
 			if( (prof->global->options and PROFILE_OPTION_HIDE_COUNTS) = 0 ) then
-				len_ = 14 - fprintf( f, !"%12lld", proc->local_count )
+				len_ = 14 - fprintf( f, fmtlld, proc->local_count )
 				pad_spaces( f, len_ )
 			end if
 
@@ -901,7 +912,7 @@ private sub hProfilerReportRawDataProc _
 	pad_spaces( f, len_ )
 
 	if( (prof->global->options and PROFILE_OPTION_HIDE_COUNTS) = 0 ) then
-		len_ = 14 - fprintf( f, !"%12lld", proc->local_count )
+		len_ = 14 - fprintf( f, fmtlld, proc->local_count )
 		pad_spaces( f, len_ )
 	end if
 
@@ -1342,7 +1353,6 @@ public function fb_EndProfile FBCALL ( byval errorlevel as long ) as long
 	hProfilerWriteReport( prof )
 
 	PROFILER_CALLS_destroy( )
-	fb_profiler = NULL
 
 	return errorlevel
 end function

--- a/profile_cycles.bas
+++ b/profile_cycles.bas
@@ -14,6 +14,17 @@
 
 extern "C"
 
+/' choose a suitable size_t printf specifier '/
+#if not defined(fmtsizet)
+	#if defined(HOST_CYGWIN)
+		#define fmtsizet "%18Iu"
+	#elif defined(HOST_WIN32)
+		#define fmtsizet "%18Iu"
+	#else
+		#define fmtsizet "%18zu"
+	#endif
+#endif
+
 '' profile section data
 extern as ubyte __start_fb_profilecycledata alias "__start_fb_profilecycledata"
 extern as ubyte __stop_fb_profilecycledata alias "__stop_fb_profilecycledata"
@@ -249,7 +260,7 @@ private sub hProfilerReport _
 		end if
 
 		fprintf( f, !"        %s\n", rec->proc_name )
-		fprintf( f, !"                %18zu %18zu %18zu\n", _
+		fprintf( f, !"                " + fmtsizet + " " + fmtsizet + " " + fmtsizet + "\n", _
 			rec->grand_total, _
 			rec->internal_total, _
 			rec->call_count _

--- a/profile_cycles.bas
+++ b/profile_cycles.bas
@@ -15,8 +15,8 @@
 extern "C"
 
 '' profile section data
-extern as long __start_fb_profilecycledata alias "__start_fb_profilecycledata"
-extern as long __stop_fb_profilecycledata alias "__stop_fb_profilecycledata"
+extern as ubyte __start_fb_profilecycledata alias "__start_fb_profilecycledata"
+extern as ubyte __stop_fb_profilecycledata alias "__stop_fb_profilecycledata"
 
 '' profiler record ids - these indicate what the record is
 enum FB_PROFILE_REDORD_ID
@@ -72,6 +72,12 @@ end type
 ''
 
 #if 0
+
+/' FIXME: creating a library with other sections causes dxe3gen to fail
+''        when building the DXE dynamic link library support for DOS
+'/
+#if !defined(HOST_DOS) 
+
 '' make sure there is at least one record in the profile data section
 static FB_PROFILE_RECORD_VERSION
 __attribute__ ((aligned (16))) prof_data_version
@@ -84,6 +90,7 @@ __attribute__((section("fb_profilecycledata"), used)) =
 
 #endif
 
+#endif
 
 dim shared as FB_PROFILER_CYCLES ptr fb_profiler = NULL
 

--- a/strw_convfrom_str.bas
+++ b/strw_convfrom_str.bas
@@ -36,13 +36,17 @@ function fb_wstr_ConvFromA( dst as FB_WCHAR ptr, dst_chars as ssize_t, src as co
 		return 0
 	end if
 
-#if defined(HOST_DOS)
+#if defined(DISABLE_WCHAR)
 	dim as ssize_t chars = strlen(src)
 	if (chars > dst_chars) then
 		chars = dst_chars
 	end if
 
 	memcpy(dst, src, chars + 1)
+
+	/* ensure that the null terminator is written, string may have been truncated */
+	dst[chars] = asc(!"\000") '' NUL CHAR
+
 	return chars
 #else
 	/' plus the null-term (note: "n" in chars, not bytes!) '/

--- a/strw_convto_str.bas
+++ b/strw_convto_str.bas
@@ -13,7 +13,7 @@ function fb_wstr_ConvToA( dst as ubyte ptr, dst_chars as ssize_t, src as const F
 		return 0
 	end if
 
-#if defined(HOST_DOS)
+#if defined(DISABLE_WCHAR)
 	dim as ssize_t chars = strlen(src)
 	if (chars > dst_chars) then
 		chars = dst_chars


### PR DESCRIPTION
This pull request imports changes from fbc 1.20.0 run time library to fbrtLib.

- fb profiler
- makefile DISABLE_WCHAR build option (replaces HOST_DOS in some places)
- Some uncicode android definitions as it relates to FB_WCHAR

Some changes were only for tidying up gcc warnings on newer gcc versions, but doesn't really affect anything in fbrtLib.  Included anyway since it does tend to help when doing a side-by-side comparison of C versus BAS files.

If nothing was missed, then this PR should bring fbrtLib up to date as of freebasic/fbc commit https://github.com/freebasic/fbc/commit/aabe1b6133696a2a19170cd41bdf8c2794df98c8